### PR TITLE
tweak in assembly equality comparer

### DIFF
--- a/src/Boo.Lang.Compiler/TypeSystem/Reflection/AssemblyEqualityComparer.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Reflection/AssemblyEqualityComparer.cs
@@ -48,7 +48,7 @@ namespace Boo.Lang.Compiler.TypeSystem
 
 		public int GetHashCode(Assembly obj)
 		{
-			return obj.FullName.GetHashCode();
+            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
 		}
 	}
 }


### PR DESCRIPTION
Sometimes I got strange 'An item with the same key has already been added' from the MemoizedFunction, but this shouldn't be possible by looking at the Invoke code. I
suspected this happens for dynamically generated assemblies (because I have seen this many times when compiling some boo-based dsl scripts) and by
heuristics concluded that there might be a problem with equality
comparer used with memoized function. Sorry, no definite test case as it was a 'heisenbug' almost impossible to reproduce reliably. Modified the assemblyequalitycomparer class, the change should not break anything - just replaced the hashcode generating method. 