### PR TITLE
Fix -D:skip.antlr=true

### DIFF
--- a/default.build
+++ b/default.build
@@ -431,7 +431,7 @@
 			</targetfiles>
 		</uptodate>
 
-		<if test="${not useful-grammars-uptodate}">
+		<if test="${not useful-grammars-uptodate and not skip.antlr}">
 			<exec program="${java}" failonerror="true">
 				<arg value="-cp" />
 				<arg file="${antlr.jar}" />


### PR DESCRIPTION
I was building boo by hand on windows, and I didn't want the java support so I used -D:skip.antlr=true. However there was a place where this wasn't checked so it was still trying to build antlr stuff so I just added a check for that in the build script